### PR TITLE
Added support for dual stream (two speaker) conversations

### DIFF
--- a/infrastructure/deployment-template.json
+++ b/infrastructure/deployment-template.json
@@ -1,9 +1,9 @@
 {
     "AWSTemplateFormatVersion": "2010-09-09",
     "Transform": "AWS::Serverless-2016-10-31",
-    "Description": "Create Lambda to Save Audio Stream in S3",
+    "Description": "Resources to process Chime Voice Connector audio from KVS, transcribe, and save output to DynamoDB table",
     "Resources": {
-        "RecodingBucket": {
+        "RecordingBucket": {
             "Type": "AWS::S3::Bucket",
             "Properties": {
                 "BucketName": {
@@ -29,7 +29,7 @@
                         "AttributeType": "S"
                     },
                     {
-                        "AttributeName": "SequenceNumber",
+                        "AttributeName": "StartTime",
                         "AttributeType": "N"
                     }
                 ],
@@ -39,7 +39,7 @@
                         "KeyType": "HASH"
                     },
                     {
-                        "AttributeName": "SequenceNumber",
+                        "AttributeName": "StartTime",
                         "KeyType": "RANGE"
                     }
                 ],
@@ -47,7 +47,7 @@
                     "ReadCapacityUnits": "5",
                     "WriteCapacityUnits": "5"
                 },
-                "TableName": "TranscriptionsData"
+                "TableName": "TranscriptSegment"
             }
         },
         "EventSQS": {
@@ -159,7 +159,7 @@
                                     ],
                                     "Resource": {
                                         "Fn::GetAtt": [
-                                            "RecodingBucket",
+                                            "RecordingBucket",
                                             "Arn"
                                         ]
                                     }
@@ -174,7 +174,7 @@
                                     "Resource": {
                                         "Fn::Join": [ "", [
                                             "arn:aws:s3:::", {
-                                              "Ref": "RecodingBucket"
+                                              "Ref": "RecordingBucket"
                                             },
                                             "/*"
                                           ]
@@ -226,7 +226,7 @@
                     "Variables": {
                         "IS_TRANSCRIBE_ENABLED": "true",
                         "RECORDINGS_BUCKET_NAME": {
-                            "Ref": "RecodingBucket"
+                            "Ref": "RecordingBucket"
                         }
                     }
                 },

--- a/src/main/java/com/amazonaws/kvstranscribestreaming/KVSTranscribeStreamingLambda.java
+++ b/src/main/java/com/amazonaws/kvstranscribestreaming/KVSTranscribeStreamingLambda.java
@@ -201,7 +201,7 @@ public class KVSTranscribeStreamingLambda implements RequestHandler<SQSEvent, St
             }
         } else {
             try {
-                logger.info("Transcibe is not enabled. Saving audio bytes to location");
+                logger.info("Transcribe is not enabled; saving audio bytes to location");
 
                 // Write audio bytes from the KVS stream to the temporary file
                 ByteBuffer audioBuffer = KVSUtils.getByteBufferFromStream(streamingMkvReader, fragmentVisitor,


### PR DESCRIPTION
*Issue #, if available:*

Added some columns in TranscriptSegments to support collecting transcripts for multiple speakers for the same CallId.
It would be great to replace this if the service was to add a leg id


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
