### PR TITLE
Increase KVS Client timeout to 15 minutes

### DIFF
--- a/src/main/java/com/amazonaws/kvstranscribestreaming/KVSTranscribeStreamingLambda.java
+++ b/src/main/java/com/amazonaws/kvstranscribestreaming/KVSTranscribeStreamingLambda.java
@@ -186,9 +186,9 @@ public class KVSTranscribeStreamingLambda implements RequestHandler<SQSEvent, St
                                 fragmentVisitor, shouldWriteAudioToFile),
                         new StreamTranscriptionBehaviorImpl(segmentWriter));
 
-                result.get(600, TimeUnit.SECONDS);
+                result.get(900, TimeUnit.SECONDS);
             } catch (TimeoutException e) {
-                logger.debug("Timing out KVS to Transcribe Streaming after 600 sec");
+                logger.debug("Timing out KVS to Transcribe Streaming after 900 sec");
 
             } catch (Exception e) {
                 logger.error("Error during streaming: ", e);


### PR DESCRIPTION
*Issue #, if available:*
15-minute call was tested but it ended up with 10 minutes. It seems the bottleneck is the KVS streaming timeout. 
*Description of changes:*
Increase the timout from 10 minutes(600 seconds) to 15 minutes so that up to 15-minute call is allowed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
