### PR TITLE
Migrate from AWS Lambda to AWS ECS to accommodate long-running transcription

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM alpine:latest
+
+RUN apk --no-cache add openjdk8 openjdk8-jre
+WORKDIR /tmp/chime-streaming-transcribe/
+ADD ./build/distributions/amazon-chime-voiceconnector-recordandtranscribe.zip /tmp/chime-streaming-transcribe/
+RUN unzip /tmp/chime-streaming-transcribe/amazon-chime-voiceconnector-recordandtranscribe.zip && rm amazon-chime-voiceconnector-recordandtranscribe.zip

--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,10 @@ dependencies {
             'software.amazon.awssdk:netty-nio-client:2.2.0',
 
             // need this for logging
-            'org.apache.commons:commons-lang3:3.6'
+            'org.apache.commons:commons-lang3:3.6',
+
+            // need for argument parsing
+            'commons-cli:commons-cli:1.4'
     )
 }
 

--- a/src/main/java/com/amazonaws/kvstranscribestreaming/AudioUtils.java
+++ b/src/main/java/com/amazonaws/kvstranscribestreaming/AudioUtils.java
@@ -64,7 +64,7 @@ public final class AudioUtils {
      * @param transactionId
      * @param awsCredentials
      */
-    public static void uploadRawAudio(Regions region, String bucketName, String keyPrefix, String audioFilePath, String transactionId, boolean publicReadAcl, AWSCredentialsProvider awsCredentials) {
+    public static void uploadRawAudio(Regions region, String bucketName, String keyPrefix, String audioFilePath, String transactionId, String startTime, boolean publicReadAcl, AWSCredentialsProvider awsCredentials) {
         File wavFile = null;
         try {
 
@@ -83,6 +83,7 @@ public final class AudioUtils {
             ObjectMetadata metadata = new ObjectMetadata();
             metadata.setContentType("audio/wav");
             metadata.addUserMetadata("transactionId", transactionId);
+            metadata.addUserMetadata("startTime", startTime);
             request.setMetadata(metadata);
 
             if (publicReadAcl) {

--- a/src/main/java/com/amazonaws/kvstranscribestreaming/MetricsUtil.java
+++ b/src/main/java/com/amazonaws/kvstranscribestreaming/MetricsUtil.java
@@ -26,7 +26,7 @@ import java.util.Date;
  */
 public class MetricsUtil {
 
-    private static String NAMESPACE = "KVSTranscribeStreamingLambda";
+    private static String NAMESPACE = "KVSTranscribeStreaming";
     private final AmazonCloudWatch amazonCloudWatch;
 
     public MetricsUtil(AmazonCloudWatch amazonCloudWatch) {

--- a/src/main/java/com/amazonaws/kvstranscribestreaming/StreamingDetail.java
+++ b/src/main/java/com/amazonaws/kvstranscribestreaming/StreamingDetail.java
@@ -1,0 +1,115 @@
+package com.amazonaws.kvstranscribestreaming;
+
+/**
+ * <p>
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * </p>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so.
+ * <p>
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+public class StreamingDetail {
+    private String streamARN;
+    private String firstFragementNumber;
+    private String transactionId;
+    private String callId;
+    private String streamingStatus;
+    private String startTime;
+
+    public StreamingDetail(final String streamARN,
+                           final String firstFragementNumber,
+                           final String transactionId,
+                           final String callId,
+                           final String streamingStatus,
+                           final String startTime
+    ) {
+        this.streamARN = streamARN;
+        this.firstFragementNumber = firstFragementNumber;
+        this.transactionId = transactionId;
+        this.callId = callId;
+        this.streamingStatus = streamingStatus;
+        this.startTime = startTime;
+    }
+
+    public String streamARN() {
+        return streamARN;
+    }
+
+    public String firstFragementNumber() {
+        return firstFragementNumber;
+    }
+
+    public String transactionId() {
+        return transactionId;
+    }
+
+    public String callId() {
+        return callId;
+    }
+
+    public String streamingStatus() {
+        return streamingStatus;
+    }
+
+    public String startTime() {
+        return startTime;
+    }
+
+    static class builder {
+        private String streamARN;
+        private String firstFragementNumber;
+        private String transactionId;
+        private String callId;
+        private String streamingStatus;
+        private String startTime;
+
+        public builder() {
+        }
+
+        public builder streamARN(final String streamARN) {
+            this.streamARN = streamARN;
+            return this;
+        }
+
+        public builder firstFragementNumber(final String firstFragementNumber) {
+            this.firstFragementNumber = firstFragementNumber;
+            return this;
+        }
+
+        public builder transactionId(final String transactionId) {
+            this.transactionId = transactionId;
+            return this;
+        }
+
+        public builder callId(final String callId) {
+            this.callId = callId;
+            return this;
+        }
+
+        public builder streamingStatus(final String streamingStatus) {
+            this.streamingStatus = streamingStatus;
+            return this;
+        }
+
+        public builder startTime(final String startTime) {
+            this.startTime = startTime;
+            return this;
+        }
+
+        public StreamingDetail build() {
+            return new StreamingDetail(streamARN, firstFragementNumber, transactionId, callId, streamingStatus, startTime);
+        }
+    }
+}

--- a/src/main/java/com/amazonaws/transcribestreaming/TranscribeStreamingRetryClient.java
+++ b/src/main/java/com/amazonaws/transcribestreaming/TranscribeStreamingRetryClient.java
@@ -43,9 +43,7 @@ import java.util.concurrent.CompletableFuture;
  */
 public class TranscribeStreamingRetryClient implements AutoCloseable {
 
-    private static final int DEFAULT_MAX_RETRIES = 5;
     private static final int DEFAULT_MAX_SLEEP_TIME_MILLS = 500;
-    private int maxRetries = DEFAULT_MAX_RETRIES;
     private int sleepTime = DEFAULT_MAX_SLEEP_TIME_MILLS;
     private final TranscribeStreamingAsyncClient client;
     private final MetricsUtil metricsUtil;
@@ -80,24 +78,6 @@ public class TranscribeStreamingRetryClient implements AutoCloseable {
     public TranscribeStreamingRetryClient(TranscribeStreamingAsyncClient client, MetricsUtil metricsUtil) {
         this.client = client;
         this.metricsUtil = metricsUtil;
-    }
-
-    /**
-     * Get Max retries
-     *
-     * @return Max retries
-     */
-    public int getMaxRetries() {
-        return maxRetries;
-    }
-
-    /**
-     * Set Max retries
-     *
-     * @param maxRetries Max retries
-     */
-    public void setMaxRetries(int maxRetries) {
-        this.maxRetries = maxRetries;
     }
 
     /**
@@ -137,7 +117,7 @@ public class TranscribeStreamingRetryClient implements AutoCloseable {
 
         CompletableFuture<Void> finalFuture = new CompletableFuture<>();
 
-        recursiveStartStream(rebuildRequestWithSession(request), publisher, responseHandler, finalFuture, 0);
+        recursiveStartStream(rebuildRequestWithSession(request), publisher, responseHandler, finalFuture);
 
         return finalFuture;
     }
@@ -149,20 +129,18 @@ public class TranscribeStreamingRetryClient implements AutoCloseable {
      * @param publisher       The source audio stream as Publisher
      * @param responseHandler StreamTranscriptionBehavior object that defines how the response needs to be handled.
      * @param finalFuture     final future to finish on completing the chained futures.
-     * @param retryAttempt    Current attempt number
      */
     private void recursiveStartStream(final StartStreamTranscriptionRequest request,
                                       final Publisher<AudioStream> publisher,
                                       final StreamTranscriptionBehavior responseHandler,
-                                      final CompletableFuture<Void> finalFuture,
-                                      final int retryAttempt) {
+                                      final CompletableFuture<Void> finalFuture) {
         CompletableFuture<Void> result = client.startStreamTranscription(request, publisher,
                 getResponseHandler(responseHandler));
         result.whenComplete((r, e) -> {
             if (e != null) {
                 logger.debug("Error occured: " + e.getMessage());
 
-                if (retryAttempt <= maxRetries && isExceptionRetriable(e)) {
+                if (isExceptionRetriable(e)) {
                     logger.debug("Retriable error occurred and will be retried.");
                     logger.debug("Sleeping for sometime before retrying...");
                     try {
@@ -171,8 +149,7 @@ public class TranscribeStreamingRetryClient implements AutoCloseable {
                         logger.error("Sleep between retries interrupted. Failed with exception: ", e);
                         finalFuture.completeExceptionally(e);
                     }
-                    logger.debug("Making retry attempt: " + (retryAttempt + 1));
-                    recursiveStartStream(request, publisher, responseHandler, finalFuture, retryAttempt + 1);
+                    recursiveStartStream(request, publisher, responseHandler, finalFuture);
                 } else {
                     metricsUtil.recordMetric("TranscribeStreamError", 1);
                     logger.error("Encountered unretriable exception or ran out of retries.", e);


### PR DESCRIPTION
*Issue #, if available:*
Current vc transcription doesn't support calls that are longer than 15 minutes. This is due to the timeout limit enforced by AWS Lambda

*Description of changes:*
This change is the code service change. Infrastructure change will be in a separate pull request.
Changes include:
1. Provide an entry point to ECS. AWS Lambda uses handler and ECS will use main(). Also add parser to parse the options passed through main. Previously event was passed through handler. With ECS, detail event, as String[] args, will pass through main().

2. Provide Dockerfile. Dockerfile will copy the java class files and jar files to the container.

What this pull request doesn't include:
1. Infrastructure change. To run on ECS, we need ECS task definition, cluster, event rule and a Lambda function. These will be included in a separate PR.
2. README. Current README will be changed to remove related Lambda content and include ECS.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
