### PR TITLE
Add dependency for event on function version to fix deployment failure

### DIFF
--- a/infrastructure/deployment-template.json
+++ b/infrastructure/deployment-template.json
@@ -445,6 +445,7 @@
     "SendRunTaskRequestLambdaEventMapping": {
       "Condition": "CreateECS",
       "Type": "AWS::Lambda::EventSourceMapping",
+      "DependsOn": ["SendRunTaskRequestLambdaFunctionVersion"],
       "Properties": {
           "Enabled": true,
           "EventSourceArn": {


### PR DESCRIPTION
*Issue #, if available:*
This is to fix the dependency failure when function event source mapping is created before function version that is auto-provisioned. Function version with provision concurrency takes longer time than regular function version because Lambda needs to provision the function and its resources during the creation time. Put a dependency here to avoid "no function version found failure" during cloudformation deployment.

*Description of changes:*
Add dependency for event source mapping on lambda function version

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
