### PR TITLE
Fix BadRequestException with signature expired during transcription

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,19 +14,19 @@ repositories {
 dependencies {
     compile group: 'io.reactivex.rxjava2', name: 'rxjava', version: '2.2.2'
     compile(
-            'software.amazon.awssdk:transcribestreaming:2.2.0',
+            'software.amazon.awssdk:transcribestreaming:2.13.10',
 
-            'com.amazonaws:aws-java-sdk-dynamodb:1.11.475',
-            'com.amazonaws:aws-java-sdk-kinesisvideo:1.11.475',
+            'com.amazonaws:aws-java-sdk-dynamodb:1.11.777',
+            'com.amazonaws:aws-java-sdk-kinesisvideo:1.11.777',
             'com.amazonaws:aws-lambda-java-core:1.2.0',
             'com.amazonaws:aws-lambda-java-events:2.2.6',
-            'com.amazonaws:aws-java-sdk-cloudwatch:1.11.592',
+            'com.amazonaws:aws-java-sdk-cloudwatch:1.11.777',
             'com.amazonaws:amazon-kinesis-video-streams-parser-library:1.0.13',
             'org.slf4j:slf4j-api:1.7.24',
             'org.slf4j:slf4j-log4j12:1.7.24',
 
             // need this for our async clients
-            'software.amazon.awssdk:netty-nio-client:2.2.0',
+            'software.amazon.awssdk:netty-nio-client:2.13.10',
 
             // need this for logging
             'org.apache.commons:commons-lang3:3.6',


### PR DESCRIPTION
*Issue #, if available:*
This is to fix the exception where signature got expired and transcription could stop.

*Description of changes:*
Revert the signer overrride change and upgrade aws-sdk-java and aws-sdk-java-v2 to the latest version

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
