### PR TITLE
Allow customer to specify either from or to number

### DIFF
--- a/infrastructure/deployment-template.json
+++ b/infrastructure/deployment-template.json
@@ -333,6 +333,10 @@
       "Condition": "CreateECS",
       "Type": "AWS::Serverless::Function",
       "Properties": {
+        "AutoPublishAlias": "Provisioned",
+        "ProvisionedConcurrencyConfig" : {
+          "ProvisionedConcurrentExecutions" : 2
+        },
         "CodeUri": "./amazon-chime-voiceconnector-recordandtranscribe.zip",
         "Environment": {
           "Variables": {
@@ -380,7 +384,7 @@
           }
         },
         "Runtime": "java11",
-        "MemorySize": 512,
+        "MemorySize": 1024,
         "Timeout": 10
       }
     },

--- a/infrastructure/deployment-template.json
+++ b/infrastructure/deployment-template.json
@@ -333,7 +333,6 @@
       "Condition": "CreateECS",
       "Type": "AWS::Serverless::Function",
       "Properties": {
-        "AutoPublishAlias": "Provisioned",
         "CodeUri": "./amazon-chime-voiceconnector-recordandtranscribe.zip",
         "Environment": {
           "Variables": {
@@ -382,10 +381,7 @@
         },
         "Runtime": "java11",
         "MemorySize": 512,
-        "Timeout": 10,
-        "ProvisionedConcurrencyConfig" : {
-          "ProvisionedConcurrentExecutions" : 2
-        }
+        "Timeout": 10
       }
     },
     "Vpc": {
@@ -723,22 +719,14 @@
       "Properties": {
         "AttributeDefinitions": [
           {
-            "AttributeName": "FromNumber",
-            "AttributeType": "S"
-          },
-          {
-            "AttributeName": "ToNumber",
+            "AttributeName": "Number",
             "AttributeType": "S"
           }
         ],
         "KeySchema": [
           {
-            "AttributeName": "FromNumber",
+            "AttributeName": "Number",
             "KeyType": "HASH"
-          },
-          {
-            "AttributeName": "ToNumber",
-            "KeyType": "RANGE"
           }
         ],
         "ProvisionedThroughput": {
@@ -746,6 +734,28 @@
           "WriteCapacityUnits": "5"
         },
         "TableName": "TranscriptionWebsocketMappingTable"
+      }
+    },
+    "TranscriptionWebsocketConnectionTable": {
+      "Type": "AWS::DynamoDB::Table",
+      "Properties": {
+        "AttributeDefinitions": [
+          {
+            "AttributeName": "ConnectionId",
+            "AttributeType": "S"
+          }
+        ],
+        "KeySchema": [
+          {
+            "AttributeName": "ConnectionId",
+            "KeyType": "HASH"
+          }
+        ],
+        "ProvisionedThroughput": {
+          "ReadCapacityUnits": "5",
+          "WriteCapacityUnits": "5"
+        },
+        "TableName": "TranscriptionWebsocketConnectionTable"
       }
     },
     "TranscriptionWebSocketIntegrationFunctionRole": {
@@ -808,12 +818,14 @@
     "TranscriptionWebSocketIntegrationFunction": {
       "Type": "AWS::Serverless::Function",
       "Properties": {
-        "AutoPublishAlias": "Provisioned",
         "CodeUri": "./amazon-chime-voiceconnector-recordandtranscribe.zip",
         "Environment": {
           "Variables": {
             "WEB_SOCKET_MAPPING_TABLE": {
               "Ref": "TranscriptionWebsocketMappingTable"
+            },
+            "WEB_SOCKET_CONNECTION_TABLE": {
+              "Ref": "TranscriptionWebsocketConnectionTable"
             },
             "TRANSCRIBE_ROUTE_KEY": "transcribe"
           }
@@ -827,10 +839,7 @@
         },
         "Runtime": "java11",
         "MemorySize": 512,
-        "Timeout": 10,
-        "ProvisionedConcurrencyConfig" : {
-          "ProvisionedConcurrentExecutions" : 2
-        }
+        "Timeout": 10
       }
     },
     "TranscriptionWebSocketIntegrationRole": {

--- a/src/main/java/com/amazonaws/kvstranscribestreaming/constants/WebSocketMappingDDBConstants.java
+++ b/src/main/java/com/amazonaws/kvstranscribestreaming/constants/WebSocketMappingDDBConstants.java
@@ -1,8 +1,7 @@
 package com.amazonaws.kvstranscribestreaming.constants;
 
-public class WebSockerMappingDDBConstants {
-    public static final String FROM_NUMBER = "FromNumber";
-    public static final String TO_NUMBER = "ToNumber";
+public class WebSocketMappingDDBConstants {
+    public static final String NUMBER = "Number";
     public static final String CONNECTION_ID = "ConnectionId";
     public static final String UPDATE_TIME = "UpdateTime";
 }

--- a/src/main/java/com/amazonaws/kvstranscribestreaming/constants/WebsocketConnectionDDBConstants.java
+++ b/src/main/java/com/amazonaws/kvstranscribestreaming/constants/WebsocketConnectionDDBConstants.java
@@ -1,0 +1,6 @@
+package com.amazonaws.kvstranscribestreaming.constants;
+
+public class WebsocketConnectionDDBConstants {
+    public static final String ASSOCIATED_NUMBERS = "AssociatedNumbers";
+    public static final String CONNECTION_ID = "ConnectionId";
+}

--- a/src/main/java/com/amazonaws/kvstranscribestreaming/docker/KVSTranscribeStreamingDocker.java
+++ b/src/main/java/com/amazonaws/kvstranscribestreaming/docker/KVSTranscribeStreamingDocker.java
@@ -2,8 +2,6 @@ package com.amazonaws.kvstranscribestreaming.docker;
 
 import com.amazonaws.kvstranscribestreaming.constants.Platform;
 import com.amazonaws.kvstranscribestreaming.handler.KVSTranscribeStreamingHandler;
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
 import org.apache.commons.cli.DefaultParser;
@@ -21,9 +19,6 @@ import org.slf4j.LoggerFactory;
 public class KVSTranscribeStreamingDocker {
     private static final Logger logger = LoggerFactory.getLogger(KVSTranscribeStreamingDocker.class);
     private static final String DOCKER_KEY_PREFIX = "KVSTranscribeStreamingDocker:";
-    private static final ObjectMapper objectMapper = new ObjectMapper()
-            .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
-
     public static void main(String[] args) {
         final KVSTranscribeStreamingHandler handler = new KVSTranscribeStreamingHandler(Platform.ECS);
         String eventBody = constructEventBody(args);

--- a/src/main/java/com/amazonaws/kvstranscribestreaming/lambda/TranscriptionWebSocketIntegrationLambda.java
+++ b/src/main/java/com/amazonaws/kvstranscribestreaming/lambda/TranscriptionWebSocketIntegrationLambda.java
@@ -46,6 +46,10 @@ public class TranscriptionWebSocketIntegrationLambda implements RequestHandler<A
     private static final String TRANSCRIBE_ROUTE_KEY = System.getenv("TRANSCRIBE_ROUTE_KEY");
     private static final String DISCONNECT_ROUTE_KEY = "$disconnect";
     private static final Regions AWS_REGION = Regions.fromName(System.getenv("AWS_REGION"));
+
+    private static final DynamoDB dynamoDB = new DynamoDB(
+            AmazonDynamoDBClientBuilder.standard().withRegion(AWS_REGION.getName()).build());
+
     @Override
     public APIGatewayV2WebSocketResponse handleRequest(APIGatewayV2WebSocketEvent requestEvent, Context context) {
         try {
@@ -64,7 +68,6 @@ public class TranscriptionWebSocketIntegrationLambda implements RequestHandler<A
                 return responseEvent;
             }
 
-            DynamoDB dynamoDB = new DynamoDB(AmazonDynamoDBClientBuilder.standard().withRegion(AWS_REGION.getName()).build());
             Table mappingTable = dynamoDB.getTable(WEB_SOCKET_MAPPING_TABLE);
             Table connectionTable = dynamoDB.getTable(WEB_SOCKET_CONNECTION_TABLE);
 

--- a/src/main/java/com/amazonaws/kvstranscribestreaming/publisher/WebSocketTranscriptionPublisher.java
+++ b/src/main/java/com/amazonaws/kvstranscribestreaming/publisher/WebSocketTranscriptionPublisher.java
@@ -158,12 +158,13 @@ public class WebSocketTranscriptionPublisher implements TranscriptionPublisher {
         nf.setMinimumFractionDigits(3);
         nf.setMaximumFractionDigits(3);
 
+        String callerLabel = String.format("Caller(%s)", detail.getFromNumber()), calleeLabel = String.format("Callee(%s)", detail.getToNumber());
         return String.format("Thread %s %d: [%s, %s] %s - %s",
                 Thread.currentThread().getName(),
                 System.currentTimeMillis(),
                 nf.format(result.startTime()),
                 nf.format(result.endTime()),
-                this.detail.getIsCaller() == Boolean.TRUE ? "spk_0" : "spk_1",
+                this.detail.getIsCaller() == Boolean.TRUE ? callerLabel : calleeLabel,
                 result.alternatives().get(0).transcript());
     }
 }


### PR DESCRIPTION
*Issue #, if available:*
This is to allow customer to enter either fromNumber or toNumber to establish the connection for transcription transmission

*Description of changes:*
1. Add the connection table to store connection-number pair. This table is going to help release resource when client disconnects the socket. 
2. API Gateway integration function changed to put item into connection table. Also the function starts to handler the disconnection(resource releasing)
3. Publisher will check the fromNumber and toNumber respectively in the mapping table. If both cannot be found then connection cannot be established.

Minor:
1. Remove provisioned concurrency. During the testing it is unstable and sometimes times out for unknown reason.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
