### PR TITLE
Add ApiGateway execute-api policy to roles

### DIFF
--- a/infrastructure/deployment-template.json
+++ b/infrastructure/deployment-template.json
@@ -249,7 +249,8 @@
           "arn:aws:iam::aws:policy/AmazonKinesisVideoStreamsReadOnlyAccess",
           "arn:aws:iam::aws:policy/AmazonTranscribeFullAccess",
           "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy",
-          "arn:aws:iam::aws:policy/AmazonDynamoDBFullAccess"
+          "arn:aws:iam::aws:policy/AmazonDynamoDBFullAccess",
+          "arn:aws:iam::aws:policy/AmazonAPIGatewayInvokeFullAccess"
         ],
         "Policies": [
           {
@@ -598,7 +599,8 @@
           "arn:aws:iam::aws:policy/service-role/AWSLambdaSQSQueueExecutionRole",
           "arn:aws:iam::aws:policy/AmazonKinesisVideoStreamsReadOnlyAccess",
           "arn:aws:iam::aws:policy/AmazonTranscribeFullAccess",
-          "arn:aws:iam::aws:policy/AmazonDynamoDBFullAccess"
+          "arn:aws:iam::aws:policy/AmazonDynamoDBFullAccess",
+          "arn:aws:iam::aws:policy/AmazonAPIGatewayInvokeFullAccess"
         ],
         "AssumeRolePolicyDocument": {
           "Version": "2012-10-17",


### PR DESCRIPTION
*Issue #, if available:*
This is to fix the permission issue that blocks customers to text websocket

*Description of changes:*
Add apigateway invoke full access to both ECS and Lambda roles

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
